### PR TITLE
yocto: Add python packages to native sdk for libcamera build

### DIFF
--- a/yocto/yocto-build.sh
+++ b/yocto/yocto-build.sh
@@ -398,6 +398,13 @@ IMAGE_INSTALL:append = "\\
      i2c-tools-misc \\
 "
 
+TOOLCHAIN_HOST_TASK:append = " \\
+    nativesdk-python3-pyyaml \\
+    nativesdk-python3-jinja2 \\
+    nativesdk-python3-ply \\
+    nativesdk-python3-sphinx \\
+"
+
 DISTRO_FEATURES += " systemd usrmerge"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED += "sysvinit"


### PR DESCRIPTION
This change adds necessary python packages into native SDK to build libcamera with SDK host tools